### PR TITLE
feat: debloat package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,7 @@
   ],
   "dependencies": {
     "easywebpack": "^4.11.5",
-    "vue-entry-loader": "^1.1.2",
-    "vue-html-loader": "^1.2.4",
-    "vue-loader": "^15.7.0",
-    "vue-template-compiler": "^2.6.10"
+    "vue-loader": "^15.7.0"
   },
   "devDependencies": {
     "axios": "^0.18.0",


### PR DESCRIPTION
Hi,

Thanks for developing this good project, which provides high-coverage tests.

I'm doing dynamic analysis on npm packages, and your project is one of my samples.

Through our dynamic analysis by running the test suites, we find that 3/5 of the direct dependencies are installed, however, they are not used during test runtime. We removed these dependencies from package.json, and installed the remaining dependencies, the tests all passed.

Would you consider creating a slim version of the package.json, which can help reduce the corresponding maintenance costs and security risks in production?